### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/cwwmillwork/dbdcafbd-dbff-4bf3-a4a1-a9a1d64f481d/798f343a-4c7b-4487-a71b-086dc7f70e44/_apis/work/boardbadge/53b4d3f8-df04-4ccb-af3e-7d66a3f2288c)](https://dev.azure.com/cwwmillwork/dbdcafbd-dbff-4bf3-a4a1-a9a1d64f481d/_boards/board/t/798f343a-4c7b-4487-a71b-086dc7f70e44/Microsoft.RequirementCategory)
 # github


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cwwmillwork/dbdcafbd-dbff-4bf3-a4a1-a9a1d64f481d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.